### PR TITLE
feat(api): send submission files directly to AI service without MCP

### DIFF
--- a/classes/assign_submission.php
+++ b/classes/assign_submission.php
@@ -308,6 +308,44 @@ class assign_submission {
     }
 
     /**
+     * Retrieves the file attachments for the current submission encoded as base64.
+     *
+     * Reads files from the assignsubmission_file plugin area and returns them
+     * ready to be included in the AI service payload.
+     *
+     * @return array Array of ['filename', 'mimetype', 'content_base64'] entries.
+     */
+    private function get_submission_files(): array {
+        if (!$this->submission) {
+            return [];
+        }
+
+        $fs = get_file_storage();
+        $context = \context_module::instance($this->assign->get_course_module()->id);
+        $files = $fs->get_area_files(
+            $context->id,
+            'assignsubmission_file',
+            'submission_files',
+            $this->submission->id,
+            'filename',
+            false
+        );
+
+        $result = [];
+        foreach ($files as $file) {
+            if ($file->get_filename() === '.') {
+                continue;
+            }
+            $result[] = [
+                'filename'       => $file->get_filename(),
+                'mimetype'       => $file->get_mimetype(),
+                'content_base64' => base64_encode($file->get_content()),
+            ];
+        }
+        return $result;
+    }
+
+    /**
      * Retrieves the onlinetext content for a given submission.
      *
      * @param stdClass $submission Submission record from {assign_submission}.
@@ -359,6 +397,7 @@ class assign_submission {
             'userid' => $this->user->id,
             'student_name' => fullname($this->user),
             'submission_assign' => self::get_submission_text($this->submission),
+            'submission_files' => $this->get_submission_files(),
             'maximum_grade' => $assignment->grade,
             'prompt' => $config->prompt,
             'lang' => $config->lang,

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_assign_ai';
-$plugin->release = '1.1.0';
-$plugin->version = 2026110305;
+$plugin->release = '1.1.1';
+$plugin->version = 2026110306;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 501];


### PR DESCRIPTION
**Compatibility note: This version is compatible from Moodle 4.5 to Moodle 5.1**.

### Added

- **File attachments are now included in the AI payload directly from Moodle.**
  A new private method `get_submission_files()` reads attached files from the `assignsubmission_file` plugin area using Moodle's file storage API. Each file is encoded as base64 and included in the AI service payload as `submission_files[]`, alongside the existing inline text submission.

### Changed

- **MCP dependency removed from the submission file discovery flow.**
  Previously, file attachments were retrieved by the AI service via an MCP call to `get_assignment_submissions`. The plugin now sends files directly in the payload, eliminating the round-trip through the MCP layer and the requirement for MCP credentials to be configured for this feature to work.

- **`build_payload()` extended with `submission_files` field.**
  The payload sent to the AI service now includes both `submission_assign` (inline text) and `submission_files` (base64-encoded attachments), allowing the AI service to evaluate PDF, DOCX, PPTX and other supported formats submitted as file attachments.

- **Version metadata updated for release packaging.**
  Plugin version bumped from `1.1.0` to `1.1.1` to reflect this change.