### PR TITLE
fix(local_assign_ai): include all config fields in backup and restore

### DIFF
--- a/backup/moodle2/backup_local_assign_ai_plugin.class.php
+++ b/backup/moodle2/backup_local_assign_ai_plugin.class.php
@@ -72,8 +72,13 @@ class backup_local_assign_ai_plugin extends backup_local_plugin {
         // Container with assignment-level configuration for local_assign_ai.
         $config = new backup_nested_element('assign_ai_config', ['id'], [
             'assignmentid',
+            'enableai',
             'autograde',
             'graderid',
+            'usedelay',
+            'delayminutes',
+            'prompt',
+            'lang',
             'usermodified',
             'timecreated',
             'timemodified',

--- a/backup/moodle2/restore_local_assign_ai_plugin.class.php
+++ b/backup/moodle2/restore_local_assign_ai_plugin.class.php
@@ -177,8 +177,13 @@ class restore_local_assign_ai_plugin extends restore_local_plugin {
 
                 $record = new stdClass();
                 $record->assignmentid = $newassignid;
+                $record->enableai = $configdata->enableai ?? null;
                 $record->autograde = $configdata->autograde;
                 $record->graderid = $this->map_userid($configdata->graderid ?? null);
+                $record->usedelay = $configdata->usedelay ?? 0;
+                $record->delayminutes = $configdata->delayminutes ?? 0;
+                $record->prompt = $configdata->prompt ?? null;
+                $record->lang = $configdata->lang ?? null;
                 $record->usermodified = $this->map_userid($configdata->usermodified ?? null);
                 $record->timecreated = !empty($configdata->timecreated) ? $configdata->timecreated : time();
                 $record->timemodified = !empty($configdata->timemodified) ? $configdata->timemodified : time();

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_assign_ai';
-$plugin->release = '1.1.1';
-$plugin->version = 2026110306;
+$plugin->release = '1.1.2';
+$plugin->version = 2026110307;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 501];


### PR DESCRIPTION
### Context

Course backup and restore of `local_assign_ai` assignment configuration was losing several fields (`enableai`, `usedelay`, `delayminutes`, `prompt`, `lang`), causing assignments to lose their AI settings after backup/restore operations.

### Description

The backup structure definition for `local_assign_ai_config` was missing 5 fields that were added in later plugin upgrades. The restore process was similarly incomplete.

### Steps to review

1. Verify the backup structure now includes all 11 fields of `local_assign_ai_config`
2. Verify the restore process handles all fields with null-coalescing fallbacks for backward compatibility
3. Run a full course backup and restore cycle with an assignment that has AI configuration

### Verification

- Backup XML structure validated against DB schema
- Restore null-coalescing operators ensure compatibility with older backups

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.

---

**Compatibility note:** This version is compatible **from Moodle 4.5 to Moodle 5.1**.

## Fixed

- **Include all config fields in course backup.**  
  The `backup_local_assign_ai_plugin` class now declares all `local_assign_ai_config` fields (`enableai`, `usedelay`, `delayminutes`, `prompt`, `lang`) in the backup nested element, ensuring they are persisted to the backup XML.

- **Restore all config fields with backward compatibility.**  
  The `restore_local_assign_ai_plugin` class now correctly maps and restores all assignment configuration fields, using null-coalescing fallbacks for backups created before these fields existed.